### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ Example using the Protocol class
     :alt: Build Status from Travis-CI
 
 
-.. |Wheel Status| image:: https://pypip.in/wheel/trollius_redis/badge.svg
+.. |Wheel Status| image:: https://img.shields.io/pypi/wheel/trollius_redis.svg
     :target: https://pypi.python.org/pypi/trollius_redis/
     :alt: Wheel Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20trollius-redis))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `trollius-redis`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.